### PR TITLE
Rest of the c-chain atomic tx construction

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/rpc"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
@@ -38,7 +39,11 @@ type Client interface {
 	Peers(context.Context, ...rpc.Option) ([]info.Peer, error)
 	GetContractInfo(ethcommon.Address, bool) (string, uint8, error)
 	CallContract(context.Context, interfaces.CallMsg, *big.Int) ([]byte, error)
+	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
+	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
+	IssueTx(ctx context.Context, txBytes []byte) (ids.ID, error)
 	GetAtomicUTXOs(ctx context.Context, addrs []string, sourceChain string, limit uint32, startAddress, startUTXOID string) ([][]byte, api.Index, error)
+	EstimateBaseFee(ctx context.Context) (*big.Int, error)
 }
 
 type EvmClient evm.Client

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -170,7 +170,7 @@ func main() {
 	}
 	pChainBackend := pchain.NewBackend(pChainClient, pIndexerParser, avaxAssetID, networkP)
 
-	cChainAtomicTxBackend := cchainatomictx.NewBackend(apiClient)
+	cChainAtomicTxBackend := cchainatomictx.NewBackend(apiClient, avaxAssetID)
 
 	handler := configureRouter(serviceConfig, asserter, apiClient, pChainBackend, cChainAtomicTxBackend)
 	if cfg.LogRequests {

--- a/mapper/cchainatomictx/helper.go
+++ b/mapper/cchainatomictx/helper.go
@@ -13,3 +13,7 @@ func IsCChainBech32Address(accountIdentifier *types.AccountIdentifier) bool {
 	}
 	return false
 }
+
+func IsAtomicOpType(t string) bool {
+	return t == mapper.OpExport || t == mapper.OpImport
+}

--- a/mapper/cchainatomictx/tx_builder.go
+++ b/mapper/cchainatomictx/tx_builder.go
@@ -1,0 +1,163 @@
+package cchainatomictx
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/coinbase/rosetta-sdk-go/parser"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+)
+
+var errMissingCoinIdentifier = errors.New("input operation does not have coin identifier")
+
+func BuildTx(opType string, matches []*parser.Match, metadata Metadata, codec codec.Manager, avaxAssetID ids.ID) (*evm.Tx, []*types.AccountIdentifier, error) {
+	switch opType {
+	case mapper.OpExport:
+		return buildExportTx(matches, metadata, codec, avaxAssetID)
+	case mapper.OpImport:
+		return buildImportTx(matches, metadata, avaxAssetID)
+	default:
+		return nil, nil, fmt.Errorf("unsupported atomic operation type %s", opType)
+	}
+}
+
+func buildExportTx(
+	matches []*parser.Match,
+	metadata Metadata,
+	codec codec.Manager,
+	avaxAssetID ids.ID,
+) (*evm.Tx, []*types.AccountIdentifier, error) {
+	ins, signers := buildIns(matches, metadata, avaxAssetID)
+
+	exportedOutputs, err := buildExportedOutputs(matches, codec, avaxAssetID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tx := &evm.Tx{UnsignedAtomicTx: &evm.UnsignedExportTx{
+		NetworkID:        metadata.NetworkID,
+		BlockchainID:     metadata.CChainID,
+		DestinationChain: *metadata.DestinationChainID,
+		Ins:              ins,
+		ExportedOutputs:  exportedOutputs,
+	}}
+	return tx, signers, nil
+}
+
+func buildImportTx(matches []*parser.Match, metadata Metadata, avaxAssetID ids.ID) (*evm.Tx, []*types.AccountIdentifier, error) {
+	importedInputs, signers, err := buildImportedInputs(matches, avaxAssetID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outs := buildOuts(matches, avaxAssetID)
+
+	tx := &evm.Tx{UnsignedAtomicTx: &evm.UnsignedImportTx{
+		NetworkID:      metadata.NetworkID,
+		BlockchainID:   metadata.CChainID,
+		SourceChain:    *metadata.SourceChainID,
+		ImportedInputs: importedInputs,
+		Outs:           outs,
+	}}
+	return tx, signers, nil
+}
+
+func buildIns(matches []*parser.Match, metadata Metadata, avaxAssetID ids.ID) ([]evm.EVMInput, []*types.AccountIdentifier) {
+	inputMatch := matches[0]
+
+	ins := []evm.EVMInput{}
+	signers := []*types.AccountIdentifier{}
+	for i, op := range inputMatch.Operations {
+		ins = append(ins, evm.EVMInput{
+			Address: ethcommon.HexToAddress(op.Account.Address),
+			Amount:  inputMatch.Amounts[i].Uint64(),
+			AssetID: avaxAssetID,
+			Nonce:   metadata.Nonce,
+		})
+		signers = append(signers, op.Account)
+	}
+	return ins, signers
+}
+
+func buildImportedInputs(matches []*parser.Match, avaxAssetID ids.ID) ([]*avax.TransferableInput, []*types.AccountIdentifier, error) {
+	inputMatch := matches[0]
+
+	importedInputs := []*avax.TransferableInput{}
+	signers := []*types.AccountIdentifier{}
+	for i, op := range inputMatch.Operations {
+		if op.CoinChange == nil || op.CoinChange.CoinIdentifier == nil {
+			return nil, nil, errMissingCoinIdentifier
+		}
+		utxoID, err := mapper.DecodeUTXOID(op.CoinChange.CoinIdentifier.Identifier)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		importedInputs = append(importedInputs, &avax.TransferableInput{
+			UTXOID: *utxoID,
+			Asset:  avax.Asset{ID: avaxAssetID},
+			In: &secp256k1fx.TransferInput{
+				Amt: inputMatch.Amounts[i].Uint64(),
+				Input: secp256k1fx.Input{
+					SigIndices: []uint32{0},
+				},
+			},
+		})
+		signers = append(signers, op.Account)
+	}
+	avax.SortTransferableInputs(importedInputs)
+
+	return importedInputs, signers, nil
+}
+
+func buildOuts(matches []*parser.Match, avaxAssetID ids.ID) []evm.EVMOutput {
+	outputMatch := matches[1]
+
+	outs := []evm.EVMOutput{}
+	for i, op := range outputMatch.Operations {
+		outs = append(outs, evm.EVMOutput{
+			Address: ethcommon.HexToAddress(op.Account.Address),
+			Amount:  outputMatch.Amounts[i].Uint64(),
+			AssetID: avaxAssetID,
+		})
+	}
+
+	return outs
+}
+
+func buildExportedOutputs(matches []*parser.Match, codec codec.Manager, avaxAssetID ids.ID) ([]*avax.TransferableOutput, error) {
+	outputMatch := matches[1]
+
+	outs := []*avax.TransferableOutput{}
+	for i, op := range outputMatch.Operations {
+		destinationAddress, err := address.ParseToID(op.Account.Address)
+		if err != nil {
+			return nil, err
+		}
+
+		outs = append(outs, &avax.TransferableOutput{
+			Asset: avax.Asset{ID: avaxAssetID},
+			Out: &secp256k1fx.TransferOutput{
+				Amt: outputMatch.Amounts[i].Uint64(),
+				OutputOwners: secp256k1fx.OutputOwners{
+					Locktime:  0,
+					Threshold: 1,
+					Addrs:     []ids.ShortID{destinationAddress},
+				},
+			},
+		})
+	}
+
+	avax.SortTransferableOutputs(outs, codec)
+
+	return outs, nil
+}

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -1,0 +1,192 @@
+package cchainatomictx
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+)
+
+var (
+	errUnknownDestinationChain  = errors.New("unknown destination chain")
+	errNoMatchingInputAddresses = errors.New("no matching input addresses")
+)
+
+type TxParser struct {
+	hrp             string
+	chainIDs        map[string]string
+	inputTxAccounts map[string]*types.AccountIdentifier
+}
+
+func NewTxParser(hrp string, chainIDs map[string]string, inputTxAccounts map[string]*types.AccountIdentifier) *TxParser {
+	return &TxParser{hrp: hrp, chainIDs: chainIDs, inputTxAccounts: inputTxAccounts}
+}
+
+func (t *TxParser) Parse(tx evm.Tx) ([]*types.Operation, error) {
+	switch unsignedTx := tx.UnsignedAtomicTx.(type) {
+	case *evm.UnsignedExportTx:
+		return t.parseExportTx(unsignedTx)
+	case *evm.UnsignedImportTx:
+		return t.parseImportTx(unsignedTx)
+	default:
+		return nil, fmt.Errorf("unsupported tx type")
+	}
+}
+
+func (t *TxParser) parseExportTx(exportTx *evm.UnsignedExportTx) ([]*types.Operation, error) {
+	operations := []*types.Operation{}
+	ins := t.insToOperations(0, mapper.OpExport, exportTx.Ins)
+
+	destinationChainID := exportTx.DestinationChain.String()
+	chainAlias, ok := t.chainIDs[destinationChainID]
+	if !ok {
+		return nil, errUnknownDestinationChain
+	}
+
+	operations = append(operations, ins...)
+	outs, err := t.exportedOutputsToOperations(len(ins), mapper.OpExport, chainAlias, exportTx.ExportedOutputs)
+	if err != nil {
+		return nil, err
+	}
+	operations = append(operations, outs...)
+
+	return operations, nil
+}
+
+func (t *TxParser) parseImportTx(importTx *evm.UnsignedImportTx) ([]*types.Operation, error) {
+	operations := []*types.Operation{}
+	ins, err := t.importedInToOperations(0, mapper.OpImport, importTx.ImportedInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	operations = append(operations, ins...)
+	outs := t.outsToOperations(len(ins), mapper.OpImport, importTx.Outs)
+	operations = append(operations, outs...)
+
+	return operations, nil
+}
+
+func (t *TxParser) insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, in := range ins {
+		inputAmount := new(big.Int).SetUint64(in.Amount)
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: idx,
+			},
+			Type:    opType,
+			Account: &types.AccountIdentifier{Address: in.Address.Hex()},
+			// Negating input amount
+			Amount: mapper.AtomicAvaxAmount(new(big.Int).Neg(inputAmount)),
+		})
+		idx++
+	}
+	return operations
+}
+
+func (t *TxParser) importedInToOperations(startIdx int64, opType string, ins []*avax.TransferableInput) ([]*types.Operation, error) {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, in := range ins {
+		inputAmount := new(big.Int).SetUint64(in.In.Amount())
+
+		utxoID := in.UTXOID.String()
+		account, ok := t.inputTxAccounts[utxoID]
+		if !ok {
+			return nil, errNoMatchingInputAddresses
+		}
+
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: idx,
+			},
+			Type:    opType,
+			Account: account,
+			// Negating input amount
+			Amount: mapper.AtomicAvaxAmount(new(big.Int).Neg(inputAmount)),
+			CoinChange: &types.CoinChange{
+				CoinIdentifier: &types.CoinIdentifier{Identifier: utxoID},
+				CoinAction:     types.CoinSpent,
+			},
+		})
+		idx++
+	}
+	return operations, nil
+}
+
+func (t *TxParser) outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, out := range outs {
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(idx),
+			},
+			Account:           &types.AccountIdentifier{Address: out.Address.Hex()},
+			RelatedOperations: buildRelatedOperations(startIdx),
+			Type:              opType,
+			Amount: &types.Amount{
+				Value:    strconv.FormatUint(out.Amount, 10),
+				Currency: mapper.AtomicAvaxCurrency,
+			},
+		})
+		idx++
+	}
+	return operations
+}
+
+func (t *TxParser) exportedOutputsToOperations(
+	startIdx int,
+	opType string,
+	chainAlias string,
+	outs []*avax.TransferableOutput,
+) ([]*types.Operation, error) {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, out := range outs {
+		var addr string
+		transferOutput := out.Output().(*secp256k1fx.TransferOutput)
+		if transferOutput != nil && len(transferOutput.Addrs) > 0 {
+			var err error
+			addr, err = address.Format(chainAlias, t.hrp, transferOutput.Addrs[0][:])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(idx),
+			},
+			Account:           &types.AccountIdentifier{Address: addr},
+			RelatedOperations: buildRelatedOperations(startIdx),
+			Type:              opType,
+			Amount: &types.Amount{
+				Value:    strconv.FormatUint(out.Out.Amount(), 10),
+				Currency: mapper.AtomicAvaxCurrency,
+			},
+		})
+		idx++
+	}
+	return operations, nil
+}
+
+func buildRelatedOperations(idx int) []*types.OperationIdentifier {
+	var identifiers []*types.OperationIdentifier
+	for i := 0; i < idx; i++ {
+		identifiers = append(identifiers, &types.OperationIdentifier{
+			Index: int64(i),
+		})
+	}
+	return identifiers
+}

--- a/mapper/cchainatomictx/types.go
+++ b/mapper/cchainatomictx/types.go
@@ -1,0 +1,30 @@
+package cchainatomictx
+
+import (
+	"math/big"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+const (
+	MetadataAtomicTxGas = "atomic_tx_gas"
+	MetadataNonce       = "nonce"
+	MetadataSourceChain = "source_chain"
+)
+
+type Metadata struct {
+	NetworkID          uint32  `json:"network_id,omitempty"`
+	CChainID           ids.ID  `json:"c_chain_id,omitempty"`
+	SourceChainID      *ids.ID `json:"source_chain_id,omitempty"`
+	DestinationChain   string  `json:"destination_chain,omitempty"`
+	DestinationChainID *ids.ID `json:"destination_chain_id,omitempty"`
+	Nonce              uint64  `json:"nonce"`
+}
+
+type Options struct {
+	AtomicTxGas      *big.Int `json:"atomic_tx_gas"`
+	From             string   `json:"from,omitempty"`
+	SourceChain      string   `json:"source_chain,omitempty"`
+	DestinationChain string   `json:"destination_chain,omitempty"`
+	Nonce            *big.Int `json:"nonce,omitempty"`
+}

--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	x2crate     = big.NewInt(1000000000)
+	X2crate     = big.NewInt(1000000000)
 	zeroAddress = common.Address{}
 )
 
@@ -175,7 +175,7 @@ func crossChainTransaction(
 					Address: out.Address.Hex(),
 				},
 				Amount: &types.Amount{
-					Value:    new(big.Int).Mul(new(big.Int).SetUint64(out.Amount), x2crate).String(),
+					Value:    new(big.Int).Mul(new(big.Int).SetUint64(out.Amount), X2crate).String(),
 					Currency: AvaxCurrency,
 				},
 				Metadata: map[string]interface{}{
@@ -207,7 +207,7 @@ func crossChainTransaction(
 					Address: in.Address.Hex(),
 				},
 				Amount: &types.Amount{
-					Value:    new(big.Int).Mul(new(big.Int).SetUint64(in.Amount), new(big.Int).Neg(x2crate)).String(),
+					Value:    new(big.Int).Mul(new(big.Int).SetUint64(in.Amount), new(big.Int).Neg(X2crate)).String(),
 					Currency: AvaxCurrency,
 				},
 				Metadata: map[string]interface{}{

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -13,6 +13,8 @@ import (
 
 	context "context"
 
+	ids "github.com/ava-labs/avalanchego/ids"
+
 	info "github.com/ava-labs/avalanchego/api/info"
 
 	interfaces "github.com/ava-labs/coreth/interfaces"
@@ -144,6 +146,29 @@ func (_m *Client) ChainID(_a0 context.Context) (*big.Int, error) {
 	return r0, r1
 }
 
+// EstimateBaseFee provides a mock function with given fields: ctx
+func (_m *Client) EstimateBaseFee(ctx context.Context) (*big.Int, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(context.Context) *big.Int); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // EstimateGas provides a mock function with given fields: _a0, _a1
 func (_m *Client) EstimateGas(_a0 context.Context, _a1 interfaces.CallMsg) (uint64, error) {
 	ret := _m.Called(_a0, _a1)
@@ -195,6 +220,36 @@ func (_m *Client) GetAtomicUTXOs(ctx context.Context, addrs []string, sourceChai
 	return r0, r1, r2
 }
 
+// GetBlockchainID provides a mock function with given fields: _a0, _a1, _a2
+func (_m *Client) GetBlockchainID(_a0 context.Context, _a1 string, _a2 ...rpc.Option) (ids.ID, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 ids.ID
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...rpc.Option) ids.ID); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(ids.ID)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...rpc.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetContractInfo provides a mock function with given fields: _a0, _a1
 func (_m *Client) GetContractInfo(_a0 common.Address, _a1 bool) (string, uint8, error) {
 	ret := _m.Called(_a0, _a1)
@@ -221,6 +276,34 @@ func (_m *Client) GetContractInfo(_a0 common.Address, _a1 bool) (string, uint8, 
 	}
 
 	return r0, r1, r2
+}
+
+// GetNetworkID provides a mock function with given fields: _a0, _a1
+func (_m *Client) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (uint32, error) {
+	_va := make([]interface{}, len(_a1))
+	for _i := range _a1 {
+		_va[_i] = _a1[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) uint32); ok {
+		r0 = rf(_a0, _a1...)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
+		r1 = rf(_a0, _a1...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetNetworkName provides a mock function with given fields: _a0, _a1
@@ -318,6 +401,29 @@ func (_m *Client) IsBootstrapped(_a0 context.Context, _a1 string, _a2 ...rpc.Opt
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, ...rpc.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// IssueTx provides a mock function with given fields: ctx, txBytes
+func (_m *Client) IssueTx(ctx context.Context, txBytes []byte) (ids.ID, error) {
+	ret := _m.Called(ctx, txBytes)
+
+	var r0 ids.ID
+	if rf, ok := ret.Get(0).(func(context.Context, []byte) ids.ID); ok {
+		r0 = rf(ctx, txBytes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(ids.ID)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []byte) error); ok {
+		r1 = rf(ctx, txBytes)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -31,7 +32,7 @@ var utxos = []utxo{
 
 func TestAccountBalance(t *testing.T) {
 	evmMock := &mocks.Client{}
-	backend := NewBackend(evmMock)
+	backend := NewBackend(evmMock, ids.Empty)
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"
 
 	t.Run("C-chain atomic tx balance is sum of UTXOs", func(t *testing.T) {
@@ -65,7 +66,7 @@ func TestAccountBalance(t *testing.T) {
 
 func TestAccountCoins(t *testing.T) {
 	evmMock := &mocks.Client{}
-	backend := NewBackend(evmMock)
+	backend := NewBackend(evmMock, ids.Empty)
 	// changing page size to 2 to test pagination as well
 	backend.getUTXOsPageSize = 2
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -3,6 +3,7 @@ package cchainatomictx
 import (
 	"testing"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
 
@@ -19,7 +20,7 @@ func TestShouldHandleRequest(t *testing.T) {
 	cBech32Address := "C-avax18xxz9e8323836t5wtpqh6fmrsjnksd6mka3gh7"
 	cEvmAddress := "0x8cBE7BdCd93FD767349074CBdD6CB69127eb0950"
 
-	backend := NewBackend(nil)
+	backend := NewBackend(nil, ids.Empty)
 
 	t.Run("should handle c-chain bech32 request", func(t *testing.T) {
 		assert.True(t, backend.ShouldHandleRequest(

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -309,10 +309,26 @@ func getTxCreds(
 	return nil, errUnknownTxType
 }
 
-func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionHash(
+	ctx context.Context,
+	req *types.ConstructionHashRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.HashTx(rosettaTx)
 }
 
-func (b *Backend) ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionSubmit(
+	ctx context.Context,
+	req *types.ConstructionSubmitRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.SubmitTx(ctx, b.cClient, rosettaTx)
 }

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -2,12 +2,16 @@ package cchainatomictx
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -16,6 +20,12 @@ import (
 	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+var (
+	errUnknownTxType = errors.New("unknown tx type")
+	errUndecodableTx = errors.New("undecodable transaction")
+	errNoTxGiven     = errors.New("no transaction was given")
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
@@ -203,11 +213,100 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hrp, err := mapper.GetHRP(req.NetworkIdentifier)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "incorrect network identifier")
+	}
+
+	chainIDs := map[string]string{}
+	if rosettaTx.DestinationChainID != nil {
+		chainIDs[rosettaTx.DestinationChainID.String()] = rosettaTx.DestinationChain
+	}
+
+	txParser := cAtomicTxParser{
+		hrp:      hrp,
+		chainIDs: chainIDs,
+	}
+
+	return common.Parse(txParser, rosettaTx, req.Signed)
+}
+
+func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaTx, error) {
+	// Unmarshal input transaction
+	payloadsTx := &common.RosettaTx{
+		Tx: &cAtomicTx{
+			Codec:        b.codec,
+			CodecVersion: b.codecVersion,
+		},
+	}
+
+	err := json.Unmarshal([]byte(transaction), payloadsTx)
+	if err != nil {
+		return nil, errUndecodableTx
+	}
+
+	if payloadsTx.Tx == nil {
+		return nil, errNoTxGiven
+	}
+
+	return payloadsTx, nil
 }
 
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.Combine(b, rosettaTx, req.Signatures)
+}
+
+func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+	cTx, ok := tx.(*cAtomicTx)
+	if !ok {
+		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")
+	}
+
+	creds, err := getTxCreds(cTx.Tx.UnsignedAtomicTx, signatures)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "unable attach signatures to transaction")
+	}
+
+	unsignedBytes, err := cTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "unable to encode unsigned transaction")
+	}
+
+	cTx.Tx.Creds = creds
+
+	signedBytes, err := cTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInternalError, "unable to marshal signed transaction")
+	}
+
+	cTx.Tx.Initialize(unsignedBytes, signedBytes)
+
+	return cTx, nil
+}
+
+// getTxCreds fetches credentials based on the tx type
+func getTxCreds(
+	unsignedAtomicTx evm.UnsignedAtomicTx,
+	signatures []*types.Signature,
+) ([]verify.Verifiable, error) {
+	switch uat := unsignedAtomicTx.(type) {
+	case *evm.UnsignedImportTx:
+		return common.BuildCredentialList(uat.ImportedInputs, signatures)
+	case *evm.UnsignedExportTx:
+		return common.BuildSingletonCredentialList(signatures)
+	}
+
+	return nil, errUnknownTxType
 }
 
 func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -194,7 +194,12 @@ func (b *Backend) calculateSuggestedFee(ctx context.Context, gasUsed *big.Int) (
 }
 
 func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	builder := cAtomicTxBuilder{
+		avaxAssetID:  b.avaxAssetID,
+		codec:        b.codec,
+		codecVersion: b.codecVersion,
+	}
+	return common.BuildPayloads(builder, req)
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -2,10 +2,18 @@ package cchainatomictx
 
 import (
 	"context"
+	"fmt"
+	"math/big"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 )
@@ -14,12 +22,175 @@ func (b *Backend) ConstructionDerive(ctx context.Context, req *types.Constructio
 	return common.DeriveBech32Address(b.fac, mapper.CChainNetworkIdentifier, req)
 }
 
-func (b *Backend) ConstructionPreprocess(ctx context.Context, req *types.ConstructionPreprocessRequest) (*types.ConstructionPreprocessResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionPreprocess(
+	ctx context.Context,
+	req *types.ConstructionPreprocessRequest,
+) (*types.ConstructionPreprocessResponse, *types.Error) {
+	matches, err := common.MatchOperations(req.Operations)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	firstIn, _ := matches[0].First()
+	firstOut, _ := matches[1].First()
+
+	if firstIn == nil || firstOut == nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "both input and output operations must be specified")
+	}
+
+	gasUsed, err := b.estimateGasUsed(firstIn.Type, matches)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	preprocessOptions := cmapper.Options{
+		AtomicTxGas: new(big.Int).SetUint64(gasUsed),
+	}
+
+	switch firstIn.Type {
+	case mapper.OpImport:
+		v, ok := req.Metadata[cmapper.MetadataSourceChain]
+		if !ok {
+			return nil, service.WrapError(service.ErrInvalidInput, "source_chain metadata must be provided")
+		}
+		chainAlias, ok := v.(string)
+		if !ok {
+			return nil, service.WrapError(service.ErrInvalidInput, "invalid source_chain value")
+		}
+
+		preprocessOptions.SourceChain = chainAlias
+	case mapper.OpExport:
+		chain, _, _, err := address.Parse(firstOut.Account.Address)
+		if err != nil {
+			return nil, service.WrapError(service.ErrInternalError, err)
+		}
+
+		preprocessOptions.From = firstIn.Account.Address
+		preprocessOptions.DestinationChain = chain
+
+		if v, ok := req.Metadata[cmapper.MetadataNonce]; ok {
+			stringObj, ok := v.(string)
+			if !ok {
+				return nil, service.WrapError(service.ErrInvalidInput, fmt.Errorf("%s is not a valid nonce string", v))
+			}
+			bigObj, ok := new(big.Int).SetString(stringObj, 10)
+			if !ok {
+				return nil, service.WrapError(service.ErrInvalidInput, fmt.Errorf("%s is not a valid nonce", v))
+			}
+			preprocessOptions.Nonce = bigObj
+		}
+	}
+
+	optionsMap, err := mapper.MarshalJSONMap(preprocessOptions)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInternalError, err)
+	}
+
+	return &types.ConstructionPreprocessResponse{
+		Options: optionsMap,
+	}, nil
 }
 
-func (b *Backend) ConstructionMetadata(ctx context.Context, req *types.ConstructionMetadataRequest) (*types.ConstructionMetadataResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) estimateGasUsed(opType string, matches []*parser.Match) (uint64, error) {
+	// building tx with dummy data to get byte size for fee estimate
+	tx, _, err := cmapper.BuildTx(opType, matches, cmapper.Metadata{
+		SourceChainID:      &ids.Empty,
+		DestinationChainID: &ids.Empty,
+	}, b.codec, b.avaxAssetID)
+	if err != nil {
+		return 0, err
+	}
+
+	err = tx.Sign(b.codec, [][]*crypto.PrivateKeySECP256K1R{})
+	if err != nil {
+		return 0, err
+	}
+
+	return tx.GasUsed(true)
+}
+
+func (b *Backend) ConstructionMetadata(
+	ctx context.Context,
+	req *types.ConstructionMetadataRequest,
+) (*types.ConstructionMetadataResponse, *types.Error) {
+	var input cmapper.Options
+	err := mapper.UnmarshalJSONMap(req.Options, &input)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	networkID, err := b.cClient.GetNetworkID(ctx)
+	if err != nil {
+		return nil, service.WrapError(service.ErrClientError, err)
+	}
+
+	cChainID, err := b.cClient.GetBlockchainID(ctx, mapper.CChainNetworkIdentifier)
+	if err != nil {
+		return nil, service.WrapError(service.ErrClientError, err)
+	}
+
+	metadata := cmapper.Metadata{
+		NetworkID: networkID,
+		CChainID:  cChainID,
+	}
+
+	if input.SourceChain != "" {
+		id, err := b.cClient.GetBlockchainID(ctx, input.SourceChain)
+		if err != nil {
+			return nil, service.WrapError(service.ErrClientError, err)
+		}
+		metadata.SourceChainID = &id
+	}
+
+	if input.DestinationChain != "" {
+		id, err := b.cClient.GetBlockchainID(ctx, input.DestinationChain)
+		if err != nil {
+			return nil, service.WrapError(service.ErrClientError, err)
+		}
+		metadata.DestinationChain = input.DestinationChain
+		metadata.DestinationChainID = &id
+	}
+
+	if input.From != "" {
+		var nonce uint64
+		if input.Nonce == nil {
+			nonce, err = b.cClient.NonceAt(ctx, ethcommon.HexToAddress(input.From), nil)
+			if err != nil {
+				return nil, service.WrapError(service.ErrClientError, err)
+			}
+		} else {
+			nonce = input.Nonce.Uint64()
+		}
+		metadata.Nonce = nonce
+	}
+
+	metadataMap, err := mapper.MarshalJSONMap(metadata)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInternalError, err)
+	}
+
+	suggestedFeeAmount, err := b.calculateSuggestedFee(ctx, input.AtomicTxGas)
+	if err != nil {
+		return nil, service.WrapError(service.ErrClientError, err)
+	}
+
+	return &types.ConstructionMetadataResponse{
+		Metadata: metadataMap,
+		SuggestedFee: []*types.Amount{
+			suggestedFeeAmount,
+		},
+	}, nil
+}
+
+func (b *Backend) calculateSuggestedFee(ctx context.Context, gasUsed *big.Int) (*types.Amount, error) {
+	baseFee, err := b.cClient.EstimateBaseFee(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	suggestedFeeEth := new(big.Int).Mul(gasUsed, baseFee)
+	suggestedFee := new(big.Int).Div(suggestedFeeEth, mapper.X2crate)
+	return mapper.AtomicAvaxAmount(suggestedFee), nil
 }
 
 func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -3,22 +3,39 @@ package cchainatomictx
 import (
 	"context"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+	mocks "github.com/ava-labs/avalanche-rosetta/mocks/client"
 	"github.com/ava-labs/avalanche-rosetta/service"
 )
 
-var networkIdentifier = &types.NetworkIdentifier{
-	Blockchain: service.BlockchainName,
-	Network:    mapper.FujiNetwork,
-}
+var (
+	networkIdentifier = &types.NetworkIdentifier{
+		Blockchain: service.BlockchainName,
+		Network:    mapper.FujiNetwork,
+	}
+
+	cAccountIdentifier       = &types.AccountIdentifier{Address: "0x3158e80abD5A1e1aa716003C9Db096792C379621"}
+	cAccountBech32Identifier = &types.AccountIdentifier{Address: "C-fuji1wmd9dfrqpud6daq0cde47u0r7pkrr46ep60399"}
+	pAccountIdentifier       = &types.AccountIdentifier{Address: "P-fuji1wmd9dfrqpud6daq0cde47u0r7pkrr46ep60399"}
+
+	cChainID, _ = ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
+	pChainID    = ids.Empty
+
+	networkID = 5
+
+	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
+)
 
 func TestConstructionDerive(t *testing.T) {
-	backend := NewBackend(nil)
+	backend := NewBackend(nil, ids.Empty)
 
 	t.Run("c-chain address", func(t *testing.T) {
 		src := "02e0d4392cfa224d4be19db416b3cf62e90fb2b7015e7b62a95c8cb490514943f6"
@@ -41,4 +58,207 @@ func TestConstructionDerive(t *testing.T) {
 			resp.AccountIdentifier.Address,
 		)
 	})
+}
+
+func TestExportTxConstruction(t *testing.T) {
+	nonce := uint64(48)
+
+	opExport := "EXPORT"
+
+	exportOperations := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 0},
+			RelatedOperations:   nil,
+			Type:                opExport,
+			Account:             cAccountIdentifier,
+			Amount:              mapper.AtomicAvaxAmount(big.NewInt(-10_000_000)),
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 1},
+			RelatedOperations: []*types.OperationIdentifier{
+				{Index: 0},
+			},
+			Type:    opExport,
+			Account: pAccountIdentifier,
+			Amount:  mapper.AtomicAvaxAmount(big.NewInt(9_719_250)),
+		},
+	}
+
+	metadataOptions := map[string]interface{}{
+		"atomic_tx_gas":     11230.,
+		"from":              cAccountIdentifier.Address,
+		"destination_chain": "P",
+	}
+
+	suggestedFeeValue := "280750"
+
+	payloadsMetadata := map[string]interface{}{
+		"network_id":           float64(networkID),
+		"c_chain_id":           cChainID.String(),
+		"destination_chain":    "P",
+		"destination_chain_id": pChainID.String(),
+		"nonce":                float64(nonce),
+	}
+
+	ctx := context.Background()
+	clientMock := &mocks.Client{}
+	backend := NewBackend(clientMock, avaxAssetID)
+
+	t.Run("preprocess endpoint", func(t *testing.T) {
+		req := &types.ConstructionPreprocessRequest{
+			NetworkIdentifier: networkIdentifier,
+			Operations:        exportOperations,
+		}
+
+		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, metadataOptions, resp.Options)
+
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("metadata endpoint", func(t *testing.T) {
+		req := &types.ConstructionMetadataRequest{
+			NetworkIdentifier: networkIdentifier,
+			Options:           metadataOptions,
+		}
+
+		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
+		clientMock.On("GetBlockchainID", ctx, "C").Return(cChainID, nil)
+		clientMock.On("GetBlockchainID", ctx, "P").Return(pChainID, nil)
+		clientMock.
+			On("NonceAt", ctx, ethcommon.HexToAddress(cAccountIdentifier.Address), (*big.Int)(nil)).
+			Return(nonce, nil)
+		clientMock.On("EstimateBaseFee", ctx).Return(big.NewInt(25_000_000_000), nil)
+
+		resp, apiErr := backend.ConstructionMetadata(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		assert.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
+
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("payloads endpoint", func(t *testing.T) {})
+
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+
+	t.Run("combine endpoint", func(t *testing.T) {})
+
+	t.Run("parse (signed) endpoint", func(t *testing.T) {})
+
+	t.Run("hash endpoint", func(t *testing.T) {})
+
+	t.Run("submit endpoint", func(t *testing.T) {})
+}
+
+func TestImportTxConstruction(t *testing.T) {
+	opImport := "IMPORT"
+
+	coinID1 := "23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj:2"
+	coinID2 := "2QmMXKS6rKQMnEh2XYZ4ZWCJmy8RpD3LyVZWxBG25t4N1JJqxY:1"
+
+	importOperations := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 0},
+			Type:                opImport,
+			Account:             cAccountBech32Identifier,
+			Amount:              mapper.AtomicAvaxAmount(big.NewInt(-15_000_000)),
+			CoinChange: &types.CoinChange{
+				CoinIdentifier: &types.CoinIdentifier{Identifier: coinID1},
+				CoinAction:     types.CoinSpent,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 1},
+			Type:                opImport,
+			Account:             cAccountBech32Identifier,
+			Amount:              mapper.AtomicAvaxAmount(big.NewInt(-5_000_000)),
+			CoinChange: &types.CoinChange{
+				CoinIdentifier: &types.CoinIdentifier{Identifier: coinID2},
+				CoinAction:     types.CoinSpent,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 2},
+			RelatedOperations: []*types.OperationIdentifier{
+				{Index: 0},
+				{Index: 1},
+			},
+			Type:    opImport,
+			Account: cAccountIdentifier,
+			Amount:  mapper.AtomicAvaxAmount(big.NewInt(19_692_050)),
+		},
+	}
+
+	preprocessMetadata := map[string]interface{}{
+		"source_chain": "P",
+	}
+
+	metadataOptions := map[string]interface{}{
+		"atomic_tx_gas": 12318.,
+		"source_chain":  "P",
+	}
+
+	suggestedFeeValue := "307950"
+
+	payloadsMetadata := map[string]interface{}{
+		"nonce":           0.,
+		"network_id":      float64(networkID),
+		"c_chain_id":      cChainID.String(),
+		"source_chain_id": pChainID.String(),
+	}
+
+	ctx := context.Background()
+	clientMock := &mocks.Client{}
+	backend := NewBackend(clientMock, avaxAssetID)
+
+	t.Run("preprocess endpoint", func(t *testing.T) {
+		req := &types.ConstructionPreprocessRequest{
+			NetworkIdentifier: networkIdentifier,
+			Operations:        importOperations,
+			Metadata:          preprocessMetadata,
+		}
+
+		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, metadataOptions, resp.Options)
+
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("metadata endpoint", func(t *testing.T) {
+		req := &types.ConstructionMetadataRequest{
+			NetworkIdentifier: networkIdentifier,
+			Options:           metadataOptions,
+		}
+
+		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
+		clientMock.On("GetBlockchainID", ctx, "C").Return(cChainID, nil)
+		clientMock.On("GetBlockchainID", ctx, "P").Return(pChainID, nil)
+		clientMock.On("EstimateBaseFee", ctx).Return(big.NewInt(25_000_000_000), nil)
+
+		resp, apiErr := backend.ConstructionMetadata(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		assert.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
+
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("payloads endpoint", func(t *testing.T) {})
+
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+
+	t.Run("combine endpoint", func(t *testing.T) {})
+
+	t.Run("parse (signed) endpoint", func(t *testing.T) {})
+
+	t.Run("hash endpoint", func(t *testing.T) {})
+
+	t.Run("submit endpoint", func(t *testing.T) {})
 }

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -3,6 +3,8 @@ package cchainatomictx
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	mocks "github.com/ava-labs/avalanche-rosetta/mocks/client"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 )
 
 var (
@@ -33,6 +36,18 @@ var (
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 )
+
+func buildRosettaSignerJSON(coinIdentifiers []string, signers []*types.AccountIdentifier) string {
+	importSigners := []*common.Signer{}
+	for i, s := range signers {
+		importSigners = append(importSigners, &common.Signer{
+			CoinIdentifier:    coinIdentifiers[i],
+			AccountIdentifier: s,
+		})
+	}
+	bytes, _ := json.Marshal(importSigners)
+	return string(bytes)
+}
 
 func TestConstructionDerive(t *testing.T) {
 	backend := NewBackend(nil, ids.Empty)
@@ -100,6 +115,23 @@ func TestExportTxConstruction(t *testing.T) {
 		"nonce":                float64(nonce),
 	}
 
+	signers := []*types.AccountIdentifier{cAccountIdentifier}
+	exportSigners := buildRosettaSignerJSON([]string{""}, signers)
+
+	unsignedExportTx := "0x000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000009896803d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000000000030000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000070000000000944dd20000000000000000000000010000000176da56a4600f1ba6f40fc3735f71e3f06c31d7590000000024739402"
+	unsignedExportTxHash, _ := hex.DecodeString("75afdcba5bf36457ba9edd65b07f40dcd3111d3c98a53550025af931b7500a7b")
+
+	signingPayloads := []*types.SigningPayload{
+		{
+			AccountIdentifier: cAccountIdentifier,
+			Bytes:             unsignedExportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+	}
+
+	wrappedTxFormat := `{"tx":"%s","signers":%s,"destination_chain":"%s","destination_chain_id":"%s"}`
+	wrappedUnsignedExportTx := fmt.Sprintf(wrappedTxFormat, unsignedExportTx, exportSigners, "P", pChainID.String())
+
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
 	backend := NewBackend(clientMock, avaxAssetID)
@@ -141,7 +173,21 @@ func TestExportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("payloads endpoint", func(t *testing.T) {})
+	t.Run("payloads endpoint", func(t *testing.T) {
+		req := &types.ConstructionPayloadsRequest{
+			NetworkIdentifier: networkIdentifier,
+			Metadata:          payloadsMetadata,
+			Operations:        exportOperations,
+		}
+
+		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
+		assert.Equal(t, signingPayloads, resp.Payloads)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
 
@@ -211,6 +257,28 @@ func TestImportTxConstruction(t *testing.T) {
 		"source_chain_id": pChainID.String(),
 	}
 
+	unsignedImportTx := "0x000000000000000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d500000000000000000000000000000000000000000000000000000000000000000000000288ae5dd070e6d74f16c26358cd4a8f43746d4d338b5b75b668741c6d95816af5000000023d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000050000000000e4e1c00000000100000000b9a824340e1b94f27500cdfcbf8eaa9d4ee5e57b2823cb8b158de17689916c74000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000000004c4b400000000100000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000012c7a123d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000000c67b0534"
+
+	unsignedImportTxHash, _ := hex.DecodeString("33f98143f7f061e262e0fabca57b7f0dc110a79073ed263fc900ebdd0c1fe6fc")
+
+	signingPayloads := []*types.SigningPayload{
+		{
+			AccountIdentifier: cAccountBech32Identifier,
+			Bytes:             unsignedImportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		{
+			AccountIdentifier: cAccountBech32Identifier,
+			Bytes:             unsignedImportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+	}
+
+	signers := []*types.AccountIdentifier{cAccountBech32Identifier, cAccountBech32Identifier}
+	importSigners := buildRosettaSignerJSON([]string{coinID1, coinID2}, signers)
+
+	wrappedUnsignedImportTx := `{"tx":"` + unsignedImportTx + `","signers":` + importSigners + `}`
+
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
 	backend := NewBackend(clientMock, avaxAssetID)
@@ -250,7 +318,21 @@ func TestImportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("payloads endpoint", func(t *testing.T) {})
+	t.Run("payloads endpoint", func(t *testing.T) {
+		req := &types.ConstructionPayloadsRequest{
+			NetworkIdentifier: networkIdentifier,
+			Metadata:          payloadsMetadata,
+			Operations:        importOperations,
+		}
+
+		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
+		assert.Equal(t, signingPayloads, resp.Payloads)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
 

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -1,6 +1,8 @@
 package cchainatomictx
 
 import (
+	"errors"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -82,4 +84,18 @@ func (c cAtomicTxBuilder) BuildTx(operations []*types.Operation, metadata map[st
 		Codec:        c.codec,
 		CodecVersion: c.codecVersion,
 	}, signers, nil
+}
+
+type cAtomicTxParser struct {
+	hrp      string
+	chainIDs map[string]string
+}
+
+func (c cAtomicTxParser) ParseTx(tx *common.RosettaTx, inputAddresses map[string]*types.AccountIdentifier) ([]*types.Operation, error) {
+	cTx, ok := tx.Tx.(*cAtomicTx)
+	if !ok {
+		return nil, errors.New("invalid transaction")
+	}
+	parser := cmapper.NewTxParser(c.hrp, c.chainIDs, inputAddresses)
+	return parser.Parse(*cTx.Tx)
 }

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -1,0 +1,85 @@
+package cchainatomictx
+
+import (
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
+	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+type cAtomicTx struct {
+	Tx           *evm.Tx
+	Codec        codec.Manager
+	CodecVersion uint16
+}
+
+func (c *cAtomicTx) Marshal() ([]byte, error) {
+	return c.Codec.Marshal(c.CodecVersion, c.Tx)
+}
+
+func (c *cAtomicTx) Unmarshal(bytes []byte) error {
+	tx := evm.Tx{}
+	_, err := c.Codec.Unmarshal(bytes, &tx)
+	if err != nil {
+		return err
+	}
+	c.Tx = &tx
+	return nil
+}
+
+func (c *cAtomicTx) SigningPayload() ([]byte, error) {
+	unsignedAtomicBytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx.UnsignedAtomicTx)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := hashing.ComputeHash256(unsignedAtomicBytes)
+	return hash, nil
+}
+
+func (c *cAtomicTx) Hash() ([]byte, error) {
+	bytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := hashing.ComputeHash256(bytes)
+	return hash, nil
+}
+
+type cAtomicTxBuilder struct {
+	avaxAssetID  ids.ID
+	codec        codec.Manager
+	codecVersion uint16
+}
+
+func (c cAtomicTxBuilder) BuildTx(operations []*types.Operation, metadata map[string]interface{}) (common.AvaxTx, []*types.AccountIdentifier, *types.Error) {
+	cMetadata := cmapper.Metadata{}
+	err := mapper.UnmarshalJSONMap(metadata, &cMetadata)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	matches, err := common.MatchOperations(operations)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	opType := matches[0].Operations[0].Type
+	tx, signers, err := cmapper.BuildTx(opType, matches, cMetadata, c.codec, c.avaxAssetID)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInternalError, err)
+	}
+
+	return &cAtomicTx{
+		Tx:           tx,
+		Codec:        c.codec,
+		CodecVersion: c.codecVersion,
+	}, signers, nil
+}

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -275,6 +275,16 @@ func BuildCredentialList(ins []*avax.TransferableInput, signatures []*types.Sign
 	return creds, nil
 }
 
+func BuildSingletonCredentialList(signatures []*types.Signature) ([]verify.Verifiable, error) {
+	offset := 0
+	cred, err := buildCredential(1, &offset, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return []verify.Verifiable{cred}, nil
+}
+
 func buildCredential(numSigs int, sigOffset *int, signatures []*types.Signature) (*secp256k1fx.Credential, error) {
 	cred := &secp256k1fx.Credential{}
 	cred.Sigs = make([][crypto.SECP256K1RSigLen]byte, numSigs)

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -1,11 +1,17 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
@@ -14,7 +20,13 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/service"
 )
 
-var errNoOperationsToMatch = errors.New("no operations were passed to match")
+var (
+	errNoOperationsToMatch      = errors.New("no operations were passed to match")
+	errInvalidInput             = errors.New("invalid input")
+	errInvalidInputSignatureLen = errors.New("input signature length doesn't match credentials needed")
+	errInsufficientSignatures   = errors.New("insufficient signatures")
+	errInvalidSignatureLen      = errors.New("invalid signature length")
+)
 
 func DeriveBech32Address(fac *crypto.FactorySECP256K1R, chainIDAlias string, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
 	pub, err := fac.ToPublicKey(req.PublicKey.Bytes)
@@ -163,5 +175,163 @@ func BuildPayloads(
 	return &types.ConstructionPayloadsResponse{
 		UnsignedTransaction: string(txJSON),
 		Payloads:            payloads,
+	}, nil
+}
+
+type TxParser interface {
+	ParseTx(tx *RosettaTx, inputAddresses map[string]*types.AccountIdentifier) ([]*types.Operation, error)
+}
+
+func Parse(parser TxParser, payloadsTx *RosettaTx, isSigned bool) (*types.ConstructionParseResponse, *types.Error) {
+	// Convert input tx into operations
+	inputAddresses := getInputAddresses(payloadsTx)
+	operations, err := parser.ParseTx(payloadsTx, inputAddresses)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "incorrect transaction input")
+	}
+
+	// Generate AccountIdentifierSigners if request is signed
+	var signers []*types.AccountIdentifier
+	if isSigned {
+		payloadSigners, err := payloadsTx.GetAccountIdentifiers(operations)
+		if err != nil {
+			return nil, service.WrapError(service.ErrInvalidInput, err)
+		}
+
+		signers = payloadSigners
+	}
+
+	return &types.ConstructionParseResponse{
+		Operations:               operations,
+		AccountIdentifierSigners: signers,
+	}, nil
+}
+
+func getInputAddresses(tx *RosettaTx) map[string]*types.AccountIdentifier {
+	addresses := make(map[string]*types.AccountIdentifier)
+
+	for _, signer := range tx.AccountIdentifierSigners {
+		addresses[signer.CoinIdentifier] = signer.AccountIdentifier
+	}
+
+	return addresses
+}
+
+type TxCombiner interface {
+	CombineTx(tx AvaxTx, signatures []*types.Signature) (AvaxTx, *types.Error)
+}
+
+func Combine(
+	combiner TxCombiner,
+	rosettaTx *RosettaTx,
+	signatures []*types.Signature,
+) (*types.ConstructionCombineResponse, *types.Error) {
+	combinedTx, tErr := combiner.CombineTx(rosettaTx.Tx, signatures)
+	if tErr != nil {
+		return nil, tErr
+	}
+
+	signedTransaction, err := json.Marshal(&RosettaTx{
+		Tx:                       combinedTx,
+		AccountIdentifierSigners: rosettaTx.AccountIdentifierSigners,
+		DestinationChain:         rosettaTx.DestinationChain,
+		DestinationChainID:       rosettaTx.DestinationChainID,
+	})
+	if err != nil {
+		return nil, service.WrapError(service.ErrInternalError, "unable to encode signed transaction")
+	}
+
+	return &types.ConstructionCombineResponse{
+		SignedTransaction: string(signedTransaction),
+	}, nil
+}
+
+// Based on tx inputs, we can determine the number of signatures
+// required by each input and put correct number of signatures to
+// construct the signed tx.
+// See https://github.com/ava-labs/avalanchego/blob/v1.7.17/vms/platformvm/txs/tx.go#L99
+// for more details.
+func BuildCredentialList(ins []*avax.TransferableInput, signatures []*types.Signature) ([]verify.Verifiable, error) {
+	creds := make([]verify.Verifiable, len(ins))
+	sigOffset := 0
+	for i, transferInput := range ins {
+		input, ok := transferInput.In.(*secp256k1fx.TransferInput)
+		if !ok {
+			return nil, errInvalidInput
+		}
+
+		cred, err := buildCredential(len(input.SigIndices), &sigOffset, signatures)
+		if err != nil {
+			return nil, err
+		}
+
+		creds[i] = cred
+	}
+
+	if sigOffset != len(signatures) {
+		return nil, errInvalidInputSignatureLen
+	}
+
+	return creds, nil
+}
+
+func buildCredential(numSigs int, sigOffset *int, signatures []*types.Signature) (*secp256k1fx.Credential, error) {
+	cred := &secp256k1fx.Credential{}
+	cred.Sigs = make([][crypto.SECP256K1RSigLen]byte, numSigs)
+	for j := 0; j < numSigs; j++ {
+		if *sigOffset >= len(signatures) {
+			return nil, errInsufficientSignatures
+		}
+
+		if len(signatures[*sigOffset].Bytes) != crypto.SECP256K1RSigLen {
+			return nil, errInvalidSignatureLen
+		}
+		copy(cred.Sigs[j][:], signatures[*sigOffset].Bytes)
+		*sigOffset++
+	}
+	return cred, nil
+}
+
+func HashTx(rosettaTx *RosettaTx) (*types.TransactionIdentifierResponse, *types.Error) {
+	txHashBytes, err := rosettaTx.Tx.Hash()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hash, err := formatting.EncodeWithChecksum(formatting.CB58, txHashBytes)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return &types.TransactionIdentifierResponse{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: hash,
+		},
+	}, nil
+}
+
+type TransactionIssuer interface {
+	IssueTx(ctx context.Context, txByte []byte) (ids.ID, error)
+}
+
+func SubmitTx(
+	ctx context.Context,
+	issuer TransactionIssuer,
+	rosettaTx *RosettaTx,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	bytes, err := rosettaTx.Tx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	txID, err := issuer.IssueTx(ctx, bytes)
+	if err != nil {
+		return nil, service.WrapError(service.ErrClientError, err)
+	}
+
+	return &types.TransactionIdentifierResponse{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: txID.String(),
+		},
 	}, nil
 }

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -2,15 +2,26 @@ package pchain
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+var (
+	errUnknownTxType = errors.New("unknown tx type")
+	errUndecodableTx = errors.New("undecodable transaction")
+	errNoTxGiven     = errors.New("no transaction was given")
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
@@ -179,17 +190,141 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hrp, err := mapper.GetHRP(req.NetworkIdentifier)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "incorrect network identifier")
+	}
+
+	chainIDs := map[string]string{}
+	if rosettaTx.DestinationChainID != nil {
+		chainIDs[rosettaTx.DestinationChainID.String()] = rosettaTx.DestinationChain
+	}
+
+	txParser := pTxParser{
+		hrp:      hrp,
+		chainIDs: chainIDs,
+	}
+
+	return common.Parse(txParser, rosettaTx, req.Signed)
 }
 
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.Combine(b, rosettaTx, req.Signatures)
 }
 
-func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+	pTx, ok := tx.(*pTx)
+	if !ok {
+		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")
+	}
+
+	ins, err := getTxInputs(pTx.Tx.UnsignedTx)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	creds, err := common.BuildCredentialList(ins, signatures)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	unsignedBytes, err := pTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	pTx.Tx.Creds = creds
+
+	signedBytes, err := pTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	pTx.Tx.Initialize(unsignedBytes, signedBytes)
+
+	return pTx, nil
 }
 
-func (b *Backend) ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+// getTxInputs fetches tx inputs based on the tx type.
+func getTxInputs(
+	unsignedTx platformvm.UnsignedTx,
+) ([]*avax.TransferableInput, error) {
+	switch utx := unsignedTx.(type) {
+	case *platformvm.UnsignedAddValidatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedAddSubnetValidatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedAddDelegatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedCreateChainTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedCreateSubnetTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedImportTx:
+		return utx.ImportedInputs, nil
+	case *platformvm.UnsignedExportTx:
+		return utx.Ins, nil
+	default:
+		return nil, errUnknownTxType
+	}
+}
+
+func (b *Backend) ConstructionHash(
+	ctx context.Context,
+	req *types.ConstructionHashRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.HashTx(rosettaTx)
+}
+
+func (b *Backend) ConstructionSubmit(
+	ctx context.Context,
+	req *types.ConstructionSubmitRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.SubmitTx(ctx, b, rosettaTx)
+}
+
+// Defining IssueTx here without rpc.Options... to be able to use it with common.SubmitTx
+func (b *Backend) IssueTx(ctx context.Context, txByte []byte) (ids.ID, error) {
+	return b.pClient.IssueTx(ctx, txByte)
+}
+
+func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaTx, error) {
+	// Unmarshal input transaction
+	payloadsTx := &common.RosettaTx{
+		Tx: &pTx{
+			Codec:        b.codec,
+			CodecVersion: b.codecVersion,
+		},
+	}
+
+	err := json.Unmarshal([]byte(transaction), payloadsTx)
+	if err != nil {
+		return nil, errUndecodableTx
+	}
+
+	if payloadsTx.Tx == nil {
+		return nil, errNoTxGiven
+	}
+
+	return payloadsTx, nil
 }


### PR DESCRIPTION
Implementations for : 
- /construction/payloads
- /construction/parse
- /construction/combine
- /construction/hash
- /construction/submit 

Using a single PR due to small amount of changes and their interdependencies to save back and forth time.